### PR TITLE
Add --disk-encryption-keys option

### DIFF
--- a/nixos-remote
+++ b/nixos-remote
@@ -214,7 +214,7 @@ if [[ -n ${disk_encryption_keys:-} ]]; then
   if [[ -d "$disk_encryption_keys" ]]; then
     disk_encryption_keys="$disk_encryption_keys/"
   fi
-  rsync -vaAXF -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "$disk_encryption_keys" "${ssh_connection#ssh://}:/tmp/"
+  rsync -vrlF -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "$disk_encryption_keys" "${ssh_connection#ssh://}:/tmp/"
 fi
 
 nixCopy --to "ssh://$ssh_connection" "$disko_script"

--- a/nixos-remote
+++ b/nixos-remote
@@ -22,6 +22,9 @@ Options:
   do not reboot after installation
 * --extra-files files
   files to copy into the new nixos installation
+* --disk-encryption-keys files
+  files to copy into the installer environment, after kexec but before installation. Can be 
+  used for things like disk encryption keys
 * --debug
   enable debug output
 USAGE
@@ -65,6 +68,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --extra-files)
       extra_files=$2
+      shift
+      ;;
+    --disk-encryption-keys)
+      disk_encryption_keys=$2
       shift
       ;;
     --stop-after-disko)
@@ -203,6 +210,13 @@ SSH
   until ssh_ -o ConnectTimeout=10 -- exit 0; do sleep 5; done
 fi
 
+if [[ -n ${disk_encryption_keys:-} ]]; then
+  if [[ -d "$disk_encryption_keys" ]]; then
+    disk_encryption_keys="$disk_encryption_keys/"
+  fi
+  rsync -vaAXF -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "$disk_encryption_keys" "${ssh_connection#ssh://}:/tmp/"
+fi
+
 nixCopy --to "ssh://$ssh_connection" "$disko_script"
 ssh_ "$disko_script"
 
@@ -220,6 +234,8 @@ fi
 
 ssh_ <<SSH
 set -efu ${enable_debug}
+# needed for installation if initrd-secrets are used
+mkdir -p /mnt/tmp
 nixos-install --no-root-passwd --no-channel-copy --system "$nixos_system"
 ${maybereboot}
 SSH

--- a/nixos-remote
+++ b/nixos-remote
@@ -14,12 +14,12 @@ Options:
   if this is give, flake is not needed
 * --no-ssh-copy
   skip copying ssh-keys to target system
+* --no-reboot
+  do not reboot after installation, allowing further customization of the target installation.
 * --kexec url
   use another kexec tarball to bootstrap NixOS
 * --stop-after-disko
   exit after disko formating, you can then proceed to install manually or some other way
-* --no-reboot
-  do not reboot after installation
 * --extra-files files
   files to copy into the new nixos installation
 * --disk-encryption-keys files

--- a/nixos-remote
+++ b/nixos-remote
@@ -235,7 +235,7 @@ fi
 ssh_ <<SSH
 set -efu ${enable_debug}
 # needed for installation if initrd-secrets are used
-mkdir -p /mnt/tmp
+mkdir -m777 -p /mnt/tmp
 nixos-install --no-root-passwd --no-channel-copy --system "$nixos_system"
 ${maybereboot}
 SSH

--- a/tests/from-nixos-with-sudo.nix
+++ b/tests/from-nixos-with-sudo.nix
@@ -1,5 +1,5 @@
 (import ./lib/test-base.nix) {
-  name = "nixos-remote";
+  name = "from-nixos-with-sudo";
   nodes = {
     installer = ./modules/installer.nix;
     installed = ./modules/installed.nix;

--- a/tests/from-nixos-with-sudo.nix
+++ b/tests/from-nixos-with-sudo.nix
@@ -6,7 +6,8 @@
   };
   testScript = ''
     start_all()
-    installer.succeed("""
+    installer.succeed("echo super-secret > /tmp/disk-encryption-key")
+    output = installer.succeed("""
       eval $(ssh-agent)
       ssh-add /etc/sshKey
       ${../nixos-remote} \
@@ -14,8 +15,14 @@
         --debug \
         --kexec /etc/nixos-remote/kexec-installer \
         --stop-after-disko \
+        --disk-encryption-keys /tmp/disk-encryption-key \
         --store-paths /etc/nixos-remote/disko /etc/nixos-remote/system-to-install \
         nixos@installed >&2
+      key=$(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+        root@installed cat /tmp/disk-encryption-key)
+      echo "encryption key: '$key'"
     """)
+
+    assert "encryption key: 'super-secret'" in output, f"output does not contain expected values: {output}"
   '';
 }

--- a/tests/from-nixos.nix
+++ b/tests/from-nixos.nix
@@ -1,5 +1,5 @@
 (import ./lib/test-base.nix) {
-  name = "nixos-remote";
+  name = "from-nixos";
   nodes = {
     installer = ./modules/installer.nix;
     installed = ./modules/installed.nix;


### PR DESCRIPTION
Similar to `--extra-files`, but files are copied before partitioning and installation. This allows to specify i.e. disk encryption keys.