### PR TITLE
Don't preserve local permissions for --extra-files

### DIFF
--- a/nixos-remote
+++ b/nixos-remote
@@ -211,7 +211,7 @@ if [[ -n ${extra_files:-} ]]; then
   if [[ -d "$extra_files" ]]; then
     extra_files="$extra_files/"
   fi
-  rsync -vaAXF -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "$extra_files" "${ssh_connection}:/mnt/"
+  rsync -vrlF -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "$extra_files" "${ssh_connection}:/mnt/"
 fi
 ssh_ << SSH
 set -efu


### PR DESCRIPTION
This changes our rsync invocation so that the remote copies of --extra-files always belong to `root:root`. I believe that's a safer default than copying local permissions in all cases. Without this change, files which should belong to root would need to locally belong to root as well. In cases where one would like other permissions on the remote system, one could chown them after copying.