### PR TITLE
allow pipes for --disk-encryption-keys...

### DIFF
--- a/nixos-remote
+++ b/nixos-remote
@@ -216,7 +216,7 @@ fi
 for path in "${!disk_encryption_keys[@]}"
 do
   echo "Uploading ${disk_encryption_keys[$path]} to $path"
-  cat "${disk_encryption_keys[$path]}" | ssh_ "cat > $path"
+  ssh_ "cat > $path" < "${disk_encryption_keys[$path]}"
 done
 
 nixCopy --to "ssh://$ssh_connection" "$disko_script"

--- a/nixos-remote
+++ b/nixos-remote
@@ -22,9 +22,9 @@ Options:
   exit after disko formating, you can then proceed to install manually or some other way
 * --extra-files files
   files to copy into the new nixos installation
-* --disk-encryption-keys files
-  files to copy into the installer environment, after kexec but before installation. Can be 
-  used for things like disk encryption keys
+* --disk-encryption-keys remote_path local_path
+  copy the contents of the file or pipe in local_path to remote_path in the installer environment,
+  after kexec but before installation. Can be repeated.
 * --debug
   enable debug output
 USAGE
@@ -38,6 +38,8 @@ abort() {
 kexec_url=https://github.com/nix-community/nixos-images/releases/download/nixos-22.11/nixos-kexec-installer-x86_64-linux.tar.gz
 enable_debug=""
 maybereboot="reboot"
+
+declare -A disk_encryption_keys
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -71,7 +73,8 @@ while [[ $# -gt 0 ]]; do
       shift
       ;;
     --disk-encryption-keys)
-      disk_encryption_keys=$2
+      disk_encryption_keys["$2"]="$3"
+      shift
       shift
       ;;
     --stop-after-disko)
@@ -210,13 +213,11 @@ SSH
   # watiting for machine to become available again
   until ssh_ -o ConnectTimeout=10 -- exit 0; do sleep 5; done
 fi
-
-if [[ -n ${disk_encryption_keys:-} ]]; then
-  if [[ -d "$disk_encryption_keys" ]]; then
-    disk_encryption_keys="$disk_encryption_keys/"
-  fi
-  rsync -vrlF -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "$disk_encryption_keys" "${ssh_connection#ssh://}:/tmp/"
-fi
+for path in "${!disk_encryption_keys[@]}"
+do
+  echo "Uploading ${disk_encryption_keys[$path]} to $path"
+  cat "${disk_encryption_keys[$path]}" | ssh_ "cat > $path"
+done
 
 nixCopy --to "ssh://$ssh_connection" "$disko_script"
 ssh_ "$disko_script"

--- a/nixos-remote
+++ b/nixos-remote
@@ -216,7 +216,7 @@ fi
 for path in "${!disk_encryption_keys[@]}"
 do
   echo "Uploading ${disk_encryption_keys[$path]} to $path"
-  ssh_ "cat > $path" < "${disk_encryption_keys[$path]}"
+  ssh_ "umask 077; cat > $path" < "${disk_encryption_keys[$path]}"
 done
 
 nixCopy --to "ssh://$ssh_connection" "$disko_script"

--- a/tests/from-nixos-with-sudo.nix
+++ b/tests/from-nixos-with-sudo.nix
@@ -6,21 +6,24 @@
   };
   testScript = ''
     start_all()
-    installer.succeed("echo super-secret > /tmp/disk-encryption-key")
+    installer.succeed("echo super-secret > /tmp/disk-1.key")
     output = installer.succeed("""
       ${../nixos-remote} \
         --no-ssh-copy-id \
         --debug \
         --kexec /etc/nixos-remote/kexec-installer \
         --stop-after-disko \
-        --disk-encryption-keys /tmp/disk-encryption-key \
+        --disk-encryption-keys /tmp/disk-1.key /tmp/disk-1.key \
+        --disk-encryption-keys /tmp/disk-2.key <(echo another-secret) \
         --store-paths /etc/nixos-remote/disko /etc/nixos-remote/system-to-install \
         nixos@installed >&2
-      key=$(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-        root@installed cat /tmp/disk-encryption-key)
-      echo "encryption key: '$key'"
+      echo "disk-1.key: '$(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+        root@installed cat /tmp/disk-1.key)'"
+      echo "disk-2.key: '$(ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+        root@installed cat /tmp/disk-2.key)'"
     """)
 
-    assert "encryption key: 'super-secret'" in output, f"output does not contain expected values: {output}"
+    assert "disk-1.key: 'super-secret'" in output, f"output does not contain expected values: {output}"
+    assert "disk-2.key: 'another-secret'" in output, f"output does not contain expected values: {output}"
   '';
 }


### PR DESCRIPTION
this allows passing multiple disk encryption keys, some of which might come in the form of unix pipes. 

It can be used with bash file substitution to pass a secret to the remote machine without writing it locally to disk.

Example

```
--disk-encryption-keys /tmp/disk-sda.key /tmp/just-a-file
--disk-encryption-keys /tmp/disk-sdb.key <(echo "top-secret") 
--disk-encryption-keys /root/another-path.key <(sops --extract '["disk-key"]' -d secrets/host.json) 
--disk-encryption-keys /tmp/disk-sdc <(sops -d secrets/disk-key.json) 
```