### PR TITLE
README: suggest the use of the packaged script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ our [example](https://github.com/numtide/nixos-remote-examples/blob/9768e438b146
 Afterwards you can just run:
 
 ```
-./nixos-remote root@yourip --flake github:your-user/your-repo#your-system
+nix run github:numtide/nixos-remote -- root@yourip --flake github:your-user/your-repo#your-system
 ```
 
 The parameter passed to `--flake` should point to your nixos configuration


### PR DESCRIPTION
Without this change users will be running the script directly and might encounter errors as they are using the script unpackaged without its dependencies.