### PR TITLE
undo require bors as required check

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -125,7 +125,15 @@ branches:
         # Required. Require branches to be up to date before merging.
         strict: true
         # Required. The list of status checks to require in order to merge into this branch
-        contexts: ["bors"]
+        contexts: [
+          "Evaluate flake.nix",
+          "package docs [x86_64-linux]",
+          "check from-nixos [x86_64-linux]",
+          "package default [x86_64-linux]",
+          "check from-nixos-with-sudo [x86_64-linux]",
+          "package nixos-remote [x86_64-linux]",
+          "deploy"
+        ]
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: false
       # Prevent merge commits from being pushed to matching branches


### PR DESCRIPTION
This stops bors from merging things... we need a better strategy here (maybe a check that only runs in staging?)