### PR TITLE
extra-files: use rsync -p, -FF

### DIFF
--- a/src/nixos-remote.sh
+++ b/src/nixos-remote.sh
@@ -244,7 +244,7 @@ if [[ -n ${extra_files:-} ]]; then
   if [[ -d $extra_files ]]; then
     extra_files="$extra_files/"
   fi
-  rsync -vrlF -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "$extra_files" "${ssh_connection}:/mnt/"
+  rsync -rlpv -FF -e "ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" "$extra_files" "${ssh_connection}:/mnt/"
 fi
 
 ssh_ <<SSH


### PR DESCRIPTION
After removing -a in #15, remote extra files are implictly chowned according to the remote umask. So we (re-)add --perms to apply local file permissions remotely as this should mostly be expected behavior.

The second -F disables uploading the .rsync-filter file itself if it exists.