### PR TITLE
fix maybesudo quotation

### DIFF
--- a/src/nixos-remote.sh
+++ b/src/nixos-remote.sh
@@ -207,8 +207,8 @@ fi
 if [[ ${is_kexec-n} == "n" ]]; then
   ssh_ <<SSH
 set -efu ${enable_debug}
-"${maybesudo}" rm -rf /root/kexec
-"${maybesudo}" mkdir -p /root/kexec
+$maybesudo rm -rf /root/kexec
+$maybesudo mkdir -p /root/kexec
 SSH
 
   if [[ -f $kexec_url ]]; then


### PR DESCRIPTION
this specific form did not work for me on machines without sudo:

```
+ '' rm -rf /root/kexec
-bash: line 2: : command not found
```