### PR TITLE
disable pseudo tty allocation in ssh

### DIFF
--- a/src/nixos-remote.sh
+++ b/src/nixos-remote.sh
@@ -110,7 +110,7 @@ timeout_ssh_() {
   timeout 10 ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$ssh_connection" "$@"
 }
 ssh_() {
-  ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$ssh_connection" "$@"
+  ssh -T -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no "$ssh_connection" "$@"
 }
 
 nix_options=(


### PR DESCRIPTION
This will get rid of pseudo tty warnings.