### PR TITLE
accept flake config by default

### DIFF
--- a/src/nixos-remote.sh
+++ b/src/nixos-remote.sh
@@ -133,6 +133,7 @@ nix_build() {
     "${nix_options[@]}" \
     --print-out-paths \
     --no-link \
+    --accept-flake-config \
     "$@"
 }
 


### PR DESCRIPTION
It seems unlikely that we deploy untrusted flakes, so this seems like a sensible default.
